### PR TITLE
Fix UnsafeLoaderWarning

### DIFF
--- a/agents/scripts/utility.py
+++ b/agents/scripts/utility.py
@@ -178,7 +178,7 @@ def load_config(logdir):
         'contain a configuration file.')
     raise IOError(message)
   with tf.gfile.FastGFile(config_path, 'r') as file_:
-    config = yaml.load(file_)
+    config = yaml.load(file_, Loader=yaml.Loader)
   message = 'Resume run and write summaries and checkpoints to {}.'
   tf.logging.info(message.format(config.logdir))
   return config


### PR DESCRIPTION
Without it such warning is displayed:

```
The default 'Loader' for 'load(stream)' without further arguments can be unsafe.
Use 'load(stream, Loader=ruamel.yaml.Loader)' explicitly if that is OK.
Alternatively include the following in your code:

  import warnings
  warnings.simplefilter('ignore', ruamel.yaml.error.UnsafeLoaderWarning)

In most other cases you should consider using 'safe_load(stream)'
  config = yaml.load(file_)
```