### PR TITLE
Cache env spaces to prevent Gym warnings.

### DIFF
--- a/agents/scripts/train.py
+++ b/agents/scripts/train.py
@@ -63,6 +63,7 @@ def _create_environment(config):
     message = "Unsupported action space '{}'".format(type(env.actions_space))
     raise NotImplementedError(message)
   env = tools.wrappers.ConvertTo32Bit(env)
+  env = tools.wrappers.CacheSpaces(env)
   return env
 
 

--- a/agents/scripts/visualize.py
+++ b/agents/scripts/visualize.py
@@ -67,6 +67,7 @@ def _create_environment(config, outdir):
     message = "Unsupported action space '{}'".format(type(env.actions_space))
     raise NotImplementedError(message)
   env = tools.wrappers.ConvertTo32Bit(env)
+  env = tools.wrappers.CacheSpaces(env)
   return env
 
 

--- a/agents/tools/nested.py
+++ b/agents/tools/nested.py
@@ -126,7 +126,7 @@ def flatten_(structure):
 
 
 def filter_(predicate, *structures, **kwargs):
-  # pylint: disable=differing-param-doc,missing-param-doc
+  # pylint: disable=differing-param-doc,missing-param-doc, too-many-branches
   """Select elements of a nested structure based on a predicate function.
 
   If multiple structures are provided as input, their structure must match and

--- a/agents/tools/wrappers.py
+++ b/agents/tools/wrappers.py
@@ -562,3 +562,36 @@ class ConvertTo32Bit(object):
     if not np.isfinite(reward).all():
       raise ValueError('Infinite reward encountered.')
     return np.array(reward, dtype=np.float32)
+
+
+class CacheSpaces(object):
+  """Cache observation and action space to not recompute them repeatedly."""
+
+  def __init__(self, env):
+    """Cache observation and action space to not recompute them repeatedly.
+
+    Args:
+      env: OpenAI Gym environment.
+    """
+    self._env = env
+    self._observation_space = self._env.observation_space
+    self._action_space = self._env.action_space
+
+  def __getattr__(self, name):
+    """Forward unimplemented attributes to the original environment.
+
+    Args:
+      name: Attribute that was accessed.
+
+    Returns:
+      Value behind the attribute name in the wrapped environment.
+    """
+    return getattr(self._env, name)
+
+  @property
+  def observation_space(self):
+    return self._observation_space
+
+  @property
+  def action_space(self):
+    return self._action_space


### PR DESCRIPTION
Many Gym environments do not specify their dtypes yet. Caching the observation and action spaces of observations means that the warnings at only shown once at the beginning an not during training.