### PR TITLE
Reduce rank of entropy tensor to avoid shape mismatch

### DIFF
--- a/agents/algorithms/ppo/ppo.py
+++ b/agents/algorithms/ppo/ppo.py
@@ -483,11 +483,11 @@ class PPO(object):
             tf.cast(kl > cutoff_threshold, tf.float32) *
             (kl - cutoff_threshold) ** 2)
       policy_loss = surrogate_loss + kl_penalty + kl_cutoff
-      entropy = policy.entropy()
+      entropy = tf.reduce_mean(policy.entropy(), axis=1)
       if self._config.entropy_regularization:
         policy_loss -= self._config.entropy_regularization * entropy
       summary = tf.summary.merge([
-          tf.summary.histogram('entropy', policy.entropy()),
+          tf.summary.histogram('entropy', entropy),
           tf.summary.histogram('kl', kl),
           tf.summary.histogram('surrogate_loss', surrogate_loss),
           tf.summary.histogram('kl_penalty', kl_penalty),


### PR DESCRIPTION
reduce entropy rank to avoids the policy_loss from broadcasting to larger shape, or it will get errors in issue#44.